### PR TITLE
fix: adjusting leeway from int to float

### DIFF
--- a/fastapi_clerk_auth/__init__.py
+++ b/fastapi_clerk_auth/__init__.py
@@ -29,7 +29,7 @@ class ClerkConfig(BaseModel):
     jwks_lifespan: int = 300
     jwks_headers: Optional[dict[str, Any]] = None
     jwks_client_timeout: int = 30
-    leeway: int = 0
+    leeway: float = 0
 
 
 class HTTPAuthorizationCredentials(FastAPIHTTPAuthorizationCredentials):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi_clerk_auth"
-version = "0.0.7"
+version = "0.0.8"
 description = "FastAPI Auth Middleware for Clerk (https://clerk.com)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
* PyJWT specifies the `leeway` field to be of type float. ([Link](https://pyjwt.readthedocs.io/en/stable/api.html#jwt.decode))